### PR TITLE
Avoid misleading message from vcam-util

### DIFF
--- a/control.c
+++ b/control.c
@@ -80,7 +80,7 @@ static int control_iocontrol_get_device(struct vcam_device_spec *dev_spec)
     strncpy((char *) &dev_spec->fb_node, (const char *) vcamfb_get_devnode(dev),
             sizeof(dev_spec->fb_node));
     snprintf((char *) &dev_spec->video_node, sizeof(dev_spec->video_node),
-             "/dev/video%d", dev->vdev.minor);
+             "/dev/video%d", dev->vdev.num);
     return 0;
 }
 

--- a/vcam-util.c
+++ b/vcam-util.c
@@ -26,7 +26,7 @@ const char *help =
     " -r --remove  idx             remove device\n"
     " -l --list                    list devices\n"
     " -s --size    WIDTHxHEIGHT    specify resolution\n"
-    " -p --pixfmt  pix_fmt         pixel format (rgb24,yuv)\n"
+    " -p --pixfmt  pix_fmt         pixel format (rgb24,yuyv)\n"
     " -d --device  /dev/*          control device node\n";
 
 enum ACTION { ACTION_NONE, ACTION_CREATE, ACTION_DESTROY, ACTION_MODIFY };
@@ -58,7 +58,7 @@ int determine_pixfmt(char *pixfmt_str)
 {
     if (!strncmp(pixfmt_str, "rgb24", 5))
         return VCAM_PIXFMT_RGB24;
-    if (!strncmp(pixfmt_str, "yuyv", 3))
+    if (!strncmp(pixfmt_str, "yuyv", 4))
         return VCAM_PIXFMT_YUYV;
     return -1;
 }


### PR DESCRIPTION
The changes focus on 'h', 'p', 'l' mode:

1. Change pixfmt information from help message for more instinct usage.
2. Fix strncmp byte length bug in function determine_pixfmt.
3. Modify ioctl VCAM_IOCTL_GET_DEVICE to reveal expected video_nr number.