### PR TITLE
Consolidate tests in scale/crop mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ You can use this command to check if the driver is ok:
 $ sudo v4l2-compliance -d /dev/videoX -f
 ```
 
-It will return a bunch of test lines, with 1 failed and 0 warnings at the end.
+It will return a bunch of test lines, with 0 failed and 0 warnings at the end.
 
 You can check if all configured formats and emulated controls are ok with this command:
 ```shell

--- a/device.h
+++ b/device.h
@@ -87,7 +87,6 @@ struct vcam_device {
     struct v4l2_pix_format input_format;
 
     struct v4l2_pix_format crop_output_format;
-    struct v4l2_rect crop_cap;
 
     /* Conversion switches */
     bool conv_pixfmt_on;

--- a/fb.c
+++ b/fb.c
@@ -438,10 +438,17 @@ int vcamfb_init(struct vcam_device *dev)
     vfb_fix.line_length = dev->input_format.bytesperline;
 
     /* set the fb_var */
-    vfb_default.xres = dev->input_format.width;
-    vfb_default.yres = dev->input_format.height;
+    if (dev->conv_crop_on) {
+        vfb_default.xres = dev->crop_output_format.width;
+        vfb_default.yres = dev->crop_output_format.height;
+    } else {
+        vfb_default.xres = dev->input_format.width;
+        vfb_default.yres = dev->input_format.height;
+    }
     vfb_default.bits_per_pixel = 24;
     vcam_fb_check_var(&vfb_default, info);
+    vfb_default.xres_virtual = dev->input_format.width;
+    vfb_default.yres_virtual = dev->input_format.height;
 
     /* set the fb_info */
     info->screen_base = (char __iomem *) fb_data->addr;


### PR DESCRIPTION
This commit focus on the problem according to issue#23. There are three
main changes:

1. Modify `TRY_FMT` to only negotiate and fill in information to user,
while `S_FMT` responsible for switching device format.
2. Initialize the expected format in `create_vcam_device` rather than
accomplish it in `S_FMT`, and open `S_FMT` scaling option for user to
switch from three kinds of resolution defined in `vcam_sizes[]`
3. Extract `negotiate_resolution` and `set_crop_resolution` function for
reuse in `TRY_FMT`, `S_FMT`, `create_vcam_device`.

The version can pass compliance test from scaling mode and cropping mode.
However the current version could not pass scaling+cropping mode in
`TRY_FMT` and `S_FMT`, which I think in current implementation is not able
to pass it. Because `G_FMT` return crop resolution, and in `TRY_FMT` will
negotiate with crop resolution which will return a new resolution type.
The test will fail when "TRY_FMT(G_FMT) != G_FMT".

The reason why we can use it normally on vlc player is that vlc will `S_FMT`
base on input_format but not the format return by `G_FMT`. I don't know
the detail how vlc player work, but it is the behavior I found.