### PR TITLE
Tweak output messages for vcam-util

### DIFF
--- a/control.c
+++ b/control.c
@@ -240,7 +240,7 @@ int request_vcam_device(struct vcam_device_spec *dev_spec)
     idx = ctldev->vcam_device_count++;
     ctldev->vcam_devices[idx] = vcam;
     spin_unlock_irqrestore(&ctldev->vcam_devices_lock, flags);
-    return idx;
+    return 0;
 }
 
 static struct control_device *alloc_control_device(void)


### PR DESCRIPTION
This patch concentrate on the cleanup of file `vcam-util.c`.

1. Enforce `stderr` for all error messages.

2. Unify coding style on `create/remove/modify/list_devices`:

- If fail to open `ctl_path`, print `stderr` and instantly return `-1`.
- If error occur in the middle of the function, print `stderr`, close `fd`
and return.
- On the last ioctl task, reserve return value, print if `stderr`,
close `fd` and return.

3. Tweak output text format:
- Always start with a Capital word and end with a period.
- Use present simple to describe a statement.
- Use present continuous to announce the task statement.
- Use past simple to declare if the task failed.