### PR TITLE
Refine image format conversions

### DIFF
--- a/device.h
+++ b/device.h
@@ -5,6 +5,7 @@
 #include <media/v4l2-common.h>
 #include <media/v4l2-device.h>
 #include <media/v4l2-ioctl.h>
+#include <media/v4l2-rect.h>
 #include <media/videobuf2-core.h>
 #include <media/videobuf2-v4l2.h>
 
@@ -96,6 +97,8 @@ struct vcam_device {
 
 struct vcam_device *create_vcam_device(size_t idx,
                                        struct vcam_device_spec *dev_spec);
+int modify_vcam_device(struct vcam_device *vcam,
+                       struct vcam_device_spec *dev_spec);
 void destroy_vcam_device(struct vcam_device *vcam);
 
 int submitter_thread(void *data);

--- a/fb.h
+++ b/fb.h
@@ -3,6 +3,8 @@
 
 #include "device.h"
 
+void set_crop_resolution(__u32 *width, __u32 *height);
+
 int vcamfb_init(struct vcam_device *dev);
 
 void vcamfb_destroy(struct vcam_device *dev);

--- a/videobuf.h
+++ b/videobuf.h
@@ -3,11 +3,6 @@
 
 #include "device.h"
 
-void swap_in_queue_buffers(struct vcam_in_queue *q);
-
-int vcam_in_queue_setup(struct vcam_in_queue *q, size_t size);
-void vcam_in_queue_destroy(struct vcam_in_queue *q);
-
 int vcam_out_videobuf2_setup(struct vcam_device *dev);
 
 #endif


### PR DESCRIPTION
There are three inconsistancy issue on the conversion mechanism:

1. According VLC source function [`SetupFormat`](https://github.com/videolan/vlc/blob/0c4a68b1e2b2eb28ec895aa4d54d48374ed4d47f/modules/access/v4l2/video.c#L417), it will acquire
resolution by calling `VIDIOC_ENUM_FRAMESIZES`, which in our definition
will return `input_format`. So vlc actually use `input_format` to convert
`output_format` from `S_FMT`. However in our origin `S_FMT` version it
behaves like `ouput_format` affect `input_format` and `vcamfb`.

2. `vcam-util -m` will call `control_iocontrol_modify_input_setting` to
reallocate `vcam_in_queue`, and `vcamfb_update` will repeatedly reallocate
the `in_queue`. These two functions need to merge.

3. In `allow_scaling=1`, `input_format` and `vcamfb` reassign according
to `output_format`, but this will restrict our capability, which in fact
we allow data transferring between input/ouput buffer with different format.

In this patch we refactor and consolidate the format conversion mechanism
with the follow features:

1. Reorganize the operations between `fb.c` and `videobuf.c`.`fb.c` response
for `in_queue` and `vcamfb`, and `videobuf.c` response for `out_queue` and
`videobuf` only.
2. If `input_format` convert, update `vcamfb` and `in_queue` in the same time.
3. `vcamfb` only affect by `input_format` and unrelate to `output_format`.
4. Allow `input_format` and `output_format` with different format when
`allow_scaling=1`. Which we allow to input any format of resolutions, and
output with supporting resolution.