### PR TITLE
Improve cropping operaions

### DIFF
--- a/device.h
+++ b/device.h
@@ -23,6 +23,7 @@
 struct vcam_in_buffer {
     void *data;
     size_t filled;
+    size_t xbar, ybar;
     uint32_t jiffies;
 };
 
@@ -87,7 +88,7 @@ struct vcam_device {
     struct v4l2_pix_format output_format;
     struct v4l2_pix_format input_format;
 
-    struct v4l2_pix_format crop_output_format;
+    struct vcam_device_spec fb_virtual_spec;
 
     /* Conversion switches */
     bool conv_pixfmt_on;

--- a/vcam.h
+++ b/vcam.h
@@ -1,6 +1,8 @@
 #ifndef VCAM_H
 #define VCAM_H
 
+#include <asm/types.h>
+
 #define VCAM_IOCTL_CREATE_DEVICE 0x111
 #define VCAM_IOCTL_DESTROY_DEVICE 0x222
 #define VCAM_IOCTL_GET_DEVICE 0x333
@@ -11,7 +13,7 @@ typedef enum { VCAM_PIXFMT_RGB24 = 0x01, VCAM_PIXFMT_YUYV = 0x02 } pixfmt_t;
 
 struct vcam_device_spec {
     unsigned int idx;
-    unsigned short width, height;
+    __u32 width, height;
     pixfmt_t pix_fmt;
     char video_node[64];
     char fb_node[64];


### PR DESCRIPTION
In the original version, by setting different size between resolution
and bytesperline, vcam can simulate cropping function on the screen.
However there is three main drawbacks:

1. vcam crop left-top partition of the screen, which in most
cases users would expect for the middle region.
2. The origin implementation is lack of expansibility to offer user
to choose their region of interest.
3. vcam doesn't make good use of the `var` information in fb device.

By speculate how FFmpeg operate in [`fbdev_enc.c`](https://github.com/FFmpeg/FFmpeg/blob/25c8507818d8559a6654a5b30a0f8aae11a48181/libavdevice/fbdev_enc.c#L100), I rewrite the
cropping mechanism by using fbdev information including `x/yres`,
`x/yres_virtual`, `x/yoffset`. Instead of copy all the information
sended from users, only select those we want to display to
`copy_from_user`.

Current version obtains the following improvement:
1. vcam is able to crop the middle region of the picture.
2. This version has the potential to offer user to choose their
region of interest, and will be my future work.
3. This version can finally pass all the v4l2-compliance when we allow
`cropping` and `scaling` together.