### PR TITLE
Support crop ratio modification

### DIFF
--- a/control.c
+++ b/control.c
@@ -70,12 +70,10 @@ static int control_iocontrol_get_device(struct vcam_device_spec *dev_spec)
         return -EINVAL;
 
     dev = ctldev->vcam_devices[dev_spec->idx];
-    dev_spec->width = dev->input_format.width;
-    dev_spec->height = dev->input_format.height;
-    if (dev->input_format.pixelformat == V4L2_PIX_FMT_YUYV)
-        dev_spec->pix_fmt = VCAM_PIXFMT_YUYV;
-    else
-        dev_spec->pix_fmt = VCAM_PIXFMT_RGB24;
+    dev_spec->width = dev->fb_spec.xres_virtual;
+    dev_spec->height = dev->fb_spec.yres_virtual;
+    dev_spec->pix_fmt = dev->fb_spec.pix_fmt;
+    dev_spec->cropratio = dev->fb_spec.cropratio;
 
     strncpy((char *) &dev_spec->fb_node, (const char *) vcamfb_get_devnode(dev),
             sizeof(dev_spec->fb_node));
@@ -174,6 +172,7 @@ static long control_ioctl(struct file *file,
 static struct vcam_device_spec default_vcam_spec = {
     .width = 640,
     .height = 480,
+    .cropratio = {.numerator = 3, .denominator = 4},
     .pix_fmt = VCAM_PIXFMT_RGB24,
 };
 

--- a/device.h
+++ b/device.h
@@ -85,10 +85,9 @@ struct vcam_device {
     size_t nr_fmts;
     struct vcam_device_format out_fmts[PIXFMTS_MAX];
 
+    struct vcam_device_spec fb_spec;
     struct v4l2_pix_format output_format;
     struct v4l2_pix_format input_format;
-
-    struct vcam_device_spec fb_virtual_spec;
 
     /* Conversion switches */
     bool conv_pixfmt_on;

--- a/fb.h
+++ b/fb.h
@@ -3,7 +3,9 @@
 
 #include "device.h"
 
-void set_crop_resolution(__u32 *width, __u32 *height);
+void set_crop_resolution(__u32 *width,
+                         __u32 *height,
+                         struct crop_ratio cropratio);
 
 int vcamfb_init(struct vcam_device *dev);
 

--- a/vcam-util.c
+++ b/vcam-util.c
@@ -20,14 +20,24 @@ const struct option long_options[] = {
     {NULL, 0, NULL, 0}};
 
 const char *help =
-    " -h --help                    Print this informations.\n"
-    " -c --create                  Create a new device.\n"
-    " -m --modify  idx             Modify a device.\n"
-    " -r --remove  idx             Remove a device.\n"
-    " -l --list                    List devices.\n"
-    " -s --size    WIDTHxHEIGHT    Specify resolution.\n"
-    " -p --pixfmt  pix_fmt         Specify pixel format (rgb24,yuyv).\n"
-    " -d --device  /dev/*          Control device node.\n";
+    " -h --help                            Print this informations.\n"
+    " -c --create                          Create a new device.\n"
+    " -m --modify  idx                     Modify a device.\n"
+    " -r --remove  idx                     Remove a device.\n"
+    " -l --list                            List devices.\n"
+    " -s --size    WIDTHxHEIGHTxCROPRATIO  Specify virtual resolution or crop "
+    "ratio.\n"
+    "                                      Crop ratio will only be applied in "
+    "cropping mode.\n"
+    "              For instance:\n"
+    "                 WxH:    640x480      Specify the virtual resolution.\n"
+    "                 CR:     5/6          Apply crop ratio to the current "
+    "resolution.\n"
+    "                 WxHxCR: 640x480x5/6  Specify the virtual resolution "
+    "and apply with crop ratio.\n"
+    "\n"
+    " -p --pixfmt  pix_fmt                 Specify pixel format (rgb24,yuyv).\n"
+    " -d --device  /dev/*                  Control device node.\n";
 
 enum ACTION { ACTION_NONE, ACTION_CREATE, ACTION_DESTROY, ACTION_MODIFY };
 
@@ -41,16 +51,45 @@ struct vcam_device_spec device_template = {
 
 static char ctl_path[128] = "/dev/vcamctl";
 
+static bool parse_cropratio(char *res_str, struct vcam_device_spec *dev)
+{
+    struct crop_ratio cropratio;
+    char *tmp = strtok(res_str, "/:,");
+    if (!tmp)
+        return false;
+
+    cropratio.numerator = atoi(tmp);
+    tmp = strtok(NULL, "/:,");
+    if (!tmp)
+        return false;
+    cropratio.denominator = atoi(tmp);
+
+    if (cropratio.numerator > cropratio.denominator ||
+        cropratio.denominator == 0)
+        return false;
+    dev->cropratio = cropratio;
+    return true;
+}
+
 bool parse_resolution(char *res_str, struct vcam_device_spec *dev)
 {
+    /* Check resolution format */
     char *tmp = strtok(res_str, "x:,");
     if (!tmp)
         return false;
-    dev->width = atoi(tmp);
+    __u32 width = atoi(tmp);
     tmp = strtok(NULL, "x:,");
+    /* Not comform to resolution format. Check crop ratio format */
     if (!tmp)
-        return false;
+        return parse_cropratio(res_str, dev);
+    dev->width = width;
     dev->height = atoi(tmp);
+
+    /* Check crop ratio format */
+    tmp = strtok(NULL, "x:,");
+    if (tmp) {
+        return parse_cropratio(tmp, dev);
+    }
     return true;
 }
 
@@ -131,6 +170,9 @@ int modify_device(struct vcam_device_spec *dev)
     if (!dev->pix_fmt)
         dev->pix_fmt = orig_dev.pix_fmt;
 
+    if (!dev->cropratio.numerator || !dev->cropratio.denominator)
+        dev->cropratio = orig_dev.cropratio;
+
     int res = ioctl(fd, VCAM_IOCTL_MODIFY_SETTING, dev);
     if (res) {
         fprintf(stderr, "Failed to modify the device.\n");
@@ -153,8 +195,10 @@ int list_devices()
     printf("Available virtual V4L2 compatible devices:\n");
     while (!ioctl(fd, VCAM_IOCTL_GET_DEVICE, &dev)) {
         dev.idx++;
-        printf("%d. %s(%d,%d,%s) -> %s\n", dev.idx, dev.fb_node, dev.width,
-               dev.height, dev.pix_fmt == VCAM_PIXFMT_RGB24 ? "rgb24" : "yuyv",
+        printf("%d. %s(%d,%d,%d/%d,%s) -> %s\n", dev.idx, dev.fb_node,
+               dev.width, dev.height, dev.cropratio.numerator,
+               dev.cropratio.denominator,
+               dev.pix_fmt == VCAM_PIXFMT_RGB24 ? "rgb24" : "yuyv",
                dev.video_node);
     }
     close(fd);
@@ -197,10 +241,12 @@ int main(int argc, char *argv[])
             break;
         case 's':
             if (!parse_resolution(optarg, &dev)) {
-                fprintf(stderr, "Failed to parse resolution.\n");
+                fprintf(stderr, "Failed to parse resolution and crop ratio.\n");
                 exit(-1);
             }
-            printf("Setting resolution to %dx%d.\n", dev.width, dev.height);
+            printf("Setting resolution to %dx%dx%d/%d.\n", dev.width,
+                   dev.height, dev.cropratio.numerator,
+                   dev.cropratio.denominator);
             break;
         case 'p':
             tmp = determine_pixfmt(optarg);

--- a/vcam.h
+++ b/vcam.h
@@ -11,9 +11,21 @@
 
 typedef enum { VCAM_PIXFMT_RGB24 = 0x01, VCAM_PIXFMT_YUYV = 0x02 } pixfmt_t;
 
+struct crop_ratio {
+    __u32 numerator;
+    __u32 denominator;
+};
+
 struct vcam_device_spec {
     unsigned int idx;
+
+    /* virtual resolution */
+    __u32 xres_virtual, yres_virtual;
+    /* resolution */
     __u32 width, height;
+
+    struct crop_ratio cropratio;
+
     pixfmt_t pix_fmt;
     char video_node[64];
     char fb_node[64];


### PR DESCRIPTION
In the original version, vcam only support fix image crop ratio
to 3/4. In this patch vcam allow users to specify crop ratio by
setting the numerator and denominator.

Users can set the device crop ratio by specify `vcam-util -s`.
`vcam-util -s` can specify `WIDTHxHEIGHT`, `CROPRATIO` or both
`WIDTHxHEIGHTxCROPRATIO`.

For example, `sudo ./vcam-util -m 1 -s 5/6` to specify crop ratio
to 5/6. `-s 1280x720x5/6` to specify both resolution to 1280x720
and crop ratio to 5/6.