### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ After running `make`, you should be able to generate the following files:
 
 Before loading this kernel module, you have to satisfy its dependency:
 ```shell
-$ sudo modprobe -a videobuf2_vmalloc videobuf2_v4l2
+$ sudo modprobe -a videobuf2-vmalloc videobuf2-v4l2
 ```
 
 The module can be loaded to Linux kernel by runnning the command:


### PR DESCRIPTION
fix the wrong mod name.

is videobuf2-vmalloc, not videobuf2_vmalloc .

same as videobuf2-v4l2

https://github.com/torvalds/linux/blob/master/drivers/media/common/videobuf2/videobuf2-vmalloc.c

https://github.com/torvalds/linux/blob/master/drivers/media/common/videobuf2/videobuf2-v4l2.c