### PR TITLE
Fix build issue with Linux v6.4 and later

### DIFF
--- a/control.c
+++ b/control.c
@@ -261,7 +261,11 @@ int __init create_control_device(const char *dev_name)
         goto kmalloc_failure;
     }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0)
+    ctldev->dev_class = class_create(dev_name);
+#else
     ctldev->dev_class = class_create(THIS_MODULE, dev_name);
+#endif
     if (!(ctldev->dev_class)) {
         pr_err("Error creating device class for control device\n");
         ret = -ENODEV;


### PR DESCRIPTION
Remove argument `THIS_MODULE` when calling class_create() if the kernel version is greater than or equal to v6.4.

In Linux Kernel v6.4, the API for class_create() was updated, reducing the number of parameters from 2 to 1. Due to this change, the original function call to class_create() will cause a 'too many arguments' error when building the kernel module.

The update for class_create() described above in the Linux Kernel source code can be viewed at: https://github.com/torvalds/linux/commit/1aaba11da9aa7d7d6b52a74d45b31cac118295a1#diff-bf5afba571cf825f63da3977a19a898d0d724fa37f0f5fbe31f4770a9ca9e39b