### PR TITLE
Fix build issues with Linux v6.8 and later

### DIFF
--- a/videobuf.c
+++ b/videobuf.c
@@ -135,7 +135,11 @@ int vcam_out_videobuf2_setup(struct vcam_device *dev)
     q->timestamp_flags = V4L2_BUF_FLAG_TIMESTAMP_MONOTONIC;
     q->ops = &vcam_vb2_ops;
     q->mem_ops = &vb2_vmalloc_memops;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0)
+    q->min_queued_buffers = 2;
+#else
     q->min_buffers_needed = 2;
+#endif
     q->lock = &dev->vcam_mutex;
 
     return vb2_queue_init(q);


### PR DESCRIPTION
1. Rename `min_buffers_needed` member in `struct vb2_queue` to `min_queued_buffers` according to the changes in Linux v6.8.
(The change described above in the Linux Kernel source code can be viewed at: https://github.com/torvalds/linux/commit/80c2b40a51393add616a1fd186a1cc10bd676a3f)

2. Remove `FBINFO_FLAG_DEFAULT` flag, as this flag was removed in Linux v6.6 and later.
(The change described above in the Linux Kernel source code can be viewed at: https://github.com/torvalds/linux/commit/0444fa357c16a4c36c6c6e3ef13e690875fad208)