### PR TITLE
Support DMA-BUF memory type in buffer queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ After running `make`, you should be able to generate the following files:
 
 Before loading this kernel module, you have to satisfy its dependency:
 ```shell
-$ sudo modprobe -a videobuf2_vmalloc videobuf2_v4l2
+$ sudo modprobe -a videobuf2_vmalloc videobuf2_v4l2 videobuf2-dma-contig
 ```
 
 The module can be loaded to Linux kernel by runnning the command:
@@ -56,7 +56,7 @@ $ sudo ./vcam-util -l
 You should get:
 ```
 Available virtual V4L2 compatible devices:
-1. fbX(640,480,rgb24) -> /dev/video0
+1. fbX(640,480,rgb24,mmap) -> /dev/video0
 ```
 
 You can use this command to check if the driver is ok:

--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ Available virtual V4L2 compatible devices:
 1. fbX(640,480,rgb24,mmap) -> /dev/video0
 ```
 
+The default memory type is MMAP. You can switch to DMA-BUF using the `-t` option, for example:
+```shell
+$ sudo ./vcam-util -c -t dmabuf
+```
+The DMA-BUF framework provides a unified way to share buffers across multiple devices.
+
 You can use this command to check if the driver is ok:
 ```shell
 $ sudo v4l2-compliance -d /dev/videoX -f

--- a/control.c
+++ b/control.c
@@ -73,6 +73,7 @@ static int control_iocontrol_get_device(struct vcam_device_spec *dev_spec)
     dev_spec->width = dev->fb_spec.xres_virtual;
     dev_spec->height = dev->fb_spec.yres_virtual;
     dev_spec->pix_fmt = dev->fb_spec.pix_fmt;
+    dev_spec->mem_type = dev->fb_spec.mem_type;
     dev_spec->cropratio = dev->fb_spec.cropratio;
 
     strncpy((char *) &dev_spec->fb_node, (const char *) vcamfb_get_devnode(dev),
@@ -174,6 +175,7 @@ static struct vcam_device_spec default_vcam_spec = {
     .height = 480,
     .cropratio = {.numerator = 3, .denominator = 4},
     .pix_fmt = VCAM_PIXFMT_RGB24,
+    .mem_type = VCAM_MEMORY_MMAP,
 };
 
 int request_vcam_device(struct vcam_device_spec *dev_spec)

--- a/device.h
+++ b/device.h
@@ -89,6 +89,9 @@ struct vcam_device {
     struct v4l2_pix_format output_format;
     struct v4l2_pix_format input_format;
 
+    /* Memory type */
+    memtype_t mem_type;
+
     /* Conversion switches */
     bool conv_pixfmt_on;
     bool conv_res_on;

--- a/vcam.h
+++ b/vcam.h
@@ -10,6 +10,7 @@
 #define VCAM_IOCTL_MODIFY_SETTING 0x555
 
 typedef enum { VCAM_PIXFMT_RGB24 = 0x01, VCAM_PIXFMT_YUYV = 0x02 } pixfmt_t;
+typedef enum { VCAM_MEMORY_MMAP = 0, VCAM_MEMORY_DMABUF = 2 } memtype_t;
 
 struct crop_ratio {
     __u32 numerator;
@@ -27,6 +28,7 @@ struct vcam_device_spec {
     struct crop_ratio cropratio;
 
     pixfmt_t pix_fmt;
+    memtype_t mem_type;
     char video_node[64];
     char fb_node[64];
 };

--- a/videobuf.c
+++ b/videobuf.c
@@ -4,6 +4,7 @@
 #include <linux/vmalloc.h>
 #include <media/videobuf2-core.h>
 #include <media/videobuf2-dma-contig.h>
+#include <media/videobuf2-vmalloc.h>
 
 #include "videobuf.h"
 
@@ -153,7 +154,15 @@ int vcam_out_videobuf2_setup(struct vcam_device *dev)
     q->buf_struct_size = sizeof(struct vcam_out_buffer);
     q->timestamp_flags = V4L2_BUF_FLAG_TIMESTAMP_MONOTONIC;
     q->ops = &vcam_vb2_ops;
-    q->mem_ops = &vb2_dma_contig_memops;
+    pr_info("memory type %d\n", dev->mem_type);
+    switch (dev->mem_type) {
+    case VCAM_MEMORY_MMAP:
+        q->mem_ops = &vb2_vmalloc_memops;
+        break;
+    case VCAM_MEMORY_DMABUF:
+        q->mem_ops = &vb2_dma_contig_memops;
+        break;
+    }
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0)
     q->min_queued_buffers = 2;
 #else


### PR DESCRIPTION
- Added VB2_DMABUF to vb2_queue.io_modes
- Set mem_ops to vb2_dma_contig_memops for physically contiguous memory
- Implemented buf_init() and buf_cleanup() to manage per-buffer state